### PR TITLE
Removed hardcoded bot channel ID in guildMemberAdd & guildMemberRemove events

### DIFF
--- a/config_template.json
+++ b/config_template.json
@@ -4,5 +4,6 @@
     "dailyAmount": 500,
     "dailyReset" : 86400000,
     "ownerID": 11111111111111111,
-    "mongoURI": "ClusterConnectionURILinkGoesHere"
+    "mongoURI": "ClusterConnectionURILinkGoesHere",
+    "botChannelID": "11111111111111111"
 }

--- a/events/guildMemberAdd.js
+++ b/events/guildMemberAdd.js
@@ -1,14 +1,13 @@
 const database = require('../database/dbFunctions');
 const Discord = require('discord.js');
 const { DateTime } = require('luxon');
+const { botChannelID } = require('../config.json');
 
 module.exports = {
     name: 'guildMemberAdd',
 
     execute(member, client, dbClient) {
 
-        // Swap this channelID for the TMBST channelID
-        const channelID = '571250035086589973';
         const userJoinedDate = DateTime.fromJSDate(member.user.createdAt)
         const userAccountAge = DateTime.now().diff(userJoinedDate,['years','months','days']).toObject();
 
@@ -16,10 +15,11 @@ module.exports = {
                 .setColor('00FF00')
                 .setAuthor(member.user.username + '#' + member.user.discriminator, member.user.displayAvatarURL())
                 .setTitle('Member Joined')
+                .setDescription('Welcome to Team Morale Boost!')
                 .addField('Account Age',`${userAccountAge.years} years, ${userAccountAge.months} months, ${Math.floor(userAccountAge.days)} days`)
                 .setTimestamp();
 
-        const channel = member.guild.channels.cache.get(channelID);
+        const channel = member.guild.channels.cache.get(botChannelID);
 
         channel.send(welcomeEmbed);
 

--- a/events/guildMemberRemove.js
+++ b/events/guildMemberRemove.js
@@ -1,13 +1,12 @@
 const database = require('../database/dbFunctions');
 const Discord = require('discord.js');
+const { botChannelID } = require('../config.json');
 
 module.exports = {
     name: 'guildMemberRemove',
 
     execute(member, client, dbClient) {
-        // Swap this channelID for the TMBST channelID
-        const channelID = '571250035086589973';
-        
+
         const leavingEmbed = new Discord.MessageEmbed()
                 .setColor('FF0000')
                 .setAuthor(member.user.username + '#' + member.user.discriminator, member.user.displayAvatarURL())
@@ -15,7 +14,7 @@ module.exports = {
                 .setDescription('They are no longer a member of Team Morale Boost.')
                 .setTimestamp();
 
-        const channel = member.guild.channels.cache.get(channelID);
+        const channel = member.guild.channels.cache.get(botChannelID);
 
         channel.send(leavingEmbed);
 


### PR DESCRIPTION
Issue: The bot is not sending a welcome/leaving embed when new users join or leave the server.

Solution: Modified config.json to include the TMBST Bot Channel ID. The ID is then used in the guildMemberAdd and guildMemberRemove event files. Also included a change to the template config.json file to include the Bot Channel ID.