### PR TITLE
New Command & Event that handles Disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 * Restart - Command that refreshes the database if users leave or join while the bot is offline.
 
 ### Voice
-* Bonk - Plays Bonk Sound Effect #2
-* David - Plays a random david sound clip
+* Play - Plays various audio files that comes included with the bot.
+* Disconnect - Manually disconnect the bot from voice chat.
 
 ## Contributing to the Project
 Team Morale Boost Discord server members are welcome to contribute to the Discord Bot.

--- a/commands/voice/disconnect.js
+++ b/commands/voice/disconnect.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const { connect } = require('http2');
+
+module.exports = {
+    name: 'disconnect',
+    aliases: ['dc'],
+    description: 'Disconnect the bot from voice chat manually.',
+    args: false,
+    usage: '!disconnect - Disconnects the bot from voice chat.',
+    guildOnly: true,
+    cooldown: 1,
+
+    async execute(message, args) {
+
+        const userVoiceChannel = message.member.voice.channel;
+
+        if (!userVoiceChannel) {
+            message.reply('You must be in a voice channel to use the disconnect command.');
+            return;
+        }
+
+        const botVoiceConnection = message.guild.voice;
+
+        if (!botVoiceConnection) {
+            message.reply('The bot must be connected to a voice channel before using the disconnect command.')
+            return;
+        }
+
+        const botVoiceChannel = botVoiceConnection.channel;
+
+        if (userVoiceChannel === botVoiceChannel) {
+            botVoiceChannel.leave();
+            message.reply('MoraleBot has been disconnected from the voice channel.')
+        }
+        else {
+            message.reply('MoraleBot is not in the same voice channel as you.')
+        }
+    }
+}

--- a/events/voiceStateUpdate.js
+++ b/events/voiceStateUpdate.js
@@ -1,0 +1,18 @@
+module.exports = {
+    name: 'voiceStateUpdate',
+
+    execute(oldState, newState) {
+        // If nobody has left the voice chat or if not the channel the bot is currently in
+        if (oldState.channelID !== oldState.guild.me.voice.channelID || newState.channel) {
+            return;
+        }
+
+        const numConnected = oldState.channel.members.size
+    
+        // Bot is the only one in voice
+        if (numConnected == 1) {
+            oldState.channel.leave();
+            console.log('LOGS: Auto-disconnected from voice due to nobody else in the call.')
+        }
+    },
+}


### PR DESCRIPTION
New Command: !disconnect 
- When users are done playing with the bot in voice chat, you can call this command to have the bot disconnect from voice chat.

New Event: voiceStateUpdate
- The code in this event will check how many users are in the voice call on each state change (user join/leave), if the number of people in the voice call is 1 (just the bot), then the bot will leave the voice call on its own.