### PR TITLE
timeout error bugfix

### DIFF
--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -57,11 +57,14 @@ module.exports = {
 			await command.execute(interaction);
 		} catch (error) {
 			console.error(error);
-
-			await interaction.reply({
-				content: "There was an error while executing this command!",
-				ephemeral: true,
-			});
+			try {
+				await interaction.reply({
+					content: "There was an error while executing this command!",
+					ephemeral: true,
+				});
+			} catch (timeout) {
+				console.error(timeout);
+			}
 		}
 	},
 };


### PR DESCRIPTION
Interactions can only be responded to for 3 seconds, but some db issues can take ~10 seconds to return bc of retry/timeouts. This fix prevents the bot from crashing in these cases.